### PR TITLE
Added material ui, tweaked for React 18 compat, fixed template format

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@testing-library/jest-dom": "^5.16.3",
         "@testing-library/react": "^12.1.4",
         "@testing-library/user-event": "^13.5.0",
+        "mui": "^0.0.1",
         "react": "^18.0.0",
         "react-dom": "^18.0.0",
         "react-router-dom": "^6.3.0",
@@ -11549,6 +11550,11 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+    },
+    "node_modules/mui": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/mui/-/mui-0.0.1.tgz",
+      "integrity": "sha1-Rppx8JMpaVJiceyTncWVmAZZB2I="
     },
     "node_modules/multicast-dns": {
       "version": "6.2.3",
@@ -24824,6 +24830,11 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+    },
+    "mui": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/mui/-/mui-0.0.1.tgz",
+      "integrity": "sha1-Rppx8JMpaVJiceyTncWVmAZZB2I="
     },
     "multicast-dns": {
       "version": "6.2.3",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "@testing-library/jest-dom": "^5.16.3",
     "@testing-library/react": "^12.1.4",
     "@testing-library/user-event": "^13.5.0",
+    "mui": "^0.0.1",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "react-router-dom": "^6.3.0",

--- a/src/components/explore/ExploreCard.jsx
+++ b/src/components/explore/ExploreCard.jsx
@@ -5,7 +5,6 @@ import { Avatar } from "@mui/material";
 
 const ExploreCard = ({username, caption, url}) => {
     return (
-       <> 
             <div className="post">
                 <div className="post_header">
                 <Avatar
@@ -18,8 +17,6 @@ const ExploreCard = ({username, caption, url}) => {
                 <img className="post_image" src={url} alt=""/>
                 <h4 className="post_text"><strong>{username}: </strong>{caption}</h4>
             </div>
-       </>
-       
     )
 }
 

--- a/src/components/explore/ExploreWrapper.jsx
+++ b/src/components/explore/ExploreWrapper.jsx
@@ -4,56 +4,57 @@ import Search from "./Search";
 
 const Wrapper = () => {
     return (
-   <>  <div><Search/></div>
-        <ExploreCard 
-          username="John Doe" 
-          url="/ExploreImages/wes-hicks-unsplash.jpg" 
-          caption="Beautiful city skyline"/>
-        <ExploreCard 
-            username="Jane Smith" 
-            url="/ExploreImages/toomas-tartes-unsplash.jpg" 
-            caption="Went hiking with a friend"/> 
-        <ExploreCard 
-            username="Damon Friedman" 
-            url="/ExploreImages/lily-banse--YHSwy6uqvk-unsplash.jpg" 
-            caption="Dinner at my favorite place"/>
-        <ExploreCard 
-            username="Allison West" 
-            url="/ExploreImages/luca-bravo-unsplash.jpg" 
-            caption="Times Square."/>
-        <ExploreCard 
-            username="Chris Summers" 
-            url="/ExploreImages/joshua-sortino-unsplash.jpg" 
-            caption="incredible atmosphere here"/>
-        <ExploreCard 
-            username="Mary Jane" 
-            url="/ExploreImages/andrey-andreyev-unsplash.jpg" 
-            caption="Views from Iceland"/>
-        <ExploreCard 
-            username="Jack Todd" 
-            url="/ExploreImages/clark-douglas-unsplash.jpg" 
-            caption="today's lunch"/> 
-        <ExploreCard 
-            username="Stephen Long" 
-            url="/ExploreImages/spacex-Ptd-iTdrCJM-unsplash.jpg" 
-            caption="Successful launch day!"/>
-        <ExploreCard 
-            username="Tommy Watford" 
-            url="/ExploreImages/joshua-koblin-unsplash.jpg" 
-            caption="Ferrari LaFerrari"/>
-        <ExploreCard 
-            username="Jack Daniels" 
-            url="/ExploreImages/alexander-popov-unsplash.jpg" 
-            caption="Last night's concert rocked"/>
-        <ExploreCard 
-            username="Nia Winter" 
-            url="/ExploreImages/marcin-ciszewski-unsplash.jpg" 
-            caption="New yacht listing"/>
-        <ExploreCard 
-            username="Eddie Strickland" 
-            url="/ExploreImages/photo-nic-unsplash.jpg" 
-            caption="Made some great memories"/>
-    </>
+        <div>
+            <Search/>
+            <ExploreCard 
+            username="John Doe" 
+            url="/ExploreImages/wes-hicks-unsplash.jpg" 
+            caption="Beautiful city skyline"/>
+            <ExploreCard 
+                username="Jane Smith" 
+                url="/ExploreImages/toomas-tartes-unsplash.jpg" 
+                caption="Went hiking with a friend"/> 
+            <ExploreCard 
+                username="Damon Friedman" 
+                url="/ExploreImages/lily-banse--YHSwy6uqvk-unsplash.jpg" 
+                caption="Dinner at my favorite place"/>
+            <ExploreCard 
+                username="Allison West" 
+                url="/ExploreImages/luca-bravo-unsplash.jpg" 
+                caption="Times Square."/>
+            <ExploreCard 
+                username="Chris Summers" 
+                url="/ExploreImages/joshua-sortino-unsplash.jpg" 
+                caption="incredible atmosphere here"/>
+            <ExploreCard 
+                username="Mary Jane" 
+                url="/ExploreImages/andrey-andreyev-unsplash.jpg" 
+                caption="Views from Iceland"/>
+            <ExploreCard 
+                username="Jack Todd" 
+                url="/ExploreImages/clark-douglas-unsplash.jpg" 
+                caption="today's lunch"/> 
+            <ExploreCard 
+                username="Stephen Long" 
+                url="/ExploreImages/spacex-Ptd-iTdrCJM-unsplash.jpg" 
+                caption="Successful launch day!"/>
+            <ExploreCard 
+                username="Tommy Watford" 
+                url="/ExploreImages/joshua-koblin-unsplash.jpg" 
+                caption="Ferrari LaFerrari"/>
+            <ExploreCard 
+                username="Jack Daniels" 
+                url="/ExploreImages/alexander-popov-unsplash.jpg" 
+                caption="Last night's concert rocked"/>
+            <ExploreCard 
+                username="Nia Winter" 
+                url="/ExploreImages/marcin-ciszewski-unsplash.jpg" 
+                caption="New yacht listing"/>
+            <ExploreCard 
+                username="Eddie Strickland" 
+                url="/ExploreImages/photo-nic-unsplash.jpg" 
+                caption="Made some great memories"/>
+        </div>
     );
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,14 +1,16 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { createRoot } from 'react-dom/client';
 import './index.css';
 import App from './App';
 import reportWebVitals from './reportWebVitals';
 
-ReactDOM.render(
+const container = document.getElementById('root');
+const root = createRoot(container);
+
+root.render(
   <React.StrictMode>
     <App />
-  </React.StrictMode>,
-  document.getElementById('root')
+  </React.StrictMode>
 );
 
 // If you want to start measuring performance in your app, pass a function


### PR DESCRIPTION
From collaboration debugging session - 

1. Material ui didn't seem to be installed correctly (possibly missing a styling engine) e.g.
`npm install @mui/material @emotion/react @emotion/styled`

2. React 18 compatibility changes ReactDOM.render to a direct render call on the root container (without having to pass the container in).
[https://reactjs.org/blog/2022/03/08/react-18-upgrade-guide.html](https://reactjs.org/blog/2022/03/08/react-18-upgrade-guide.html)

3. Removed outer Fragments from Components in ExploreCard but not necessarily a bug - just couldn't tell exactly if they were needed.  See diff to place back if they are. 